### PR TITLE
Fixed a memory leak

### DIFF
--- a/iOS-WebP/UIImage+WebP.m
+++ b/iOS-WebP/UIImage+WebP.m
@@ -14,10 +14,10 @@ static void free_image_data(void *info, const void *data, size_t size)
     if(info != NULL) {
         WebPFreeDecBuffer(&(((WebPDecoderConfig *) info)->output));
         free(info);
-    } else {
-        free((void *) data);
     }
+        free((void *) data);
 }
+
 
 @implementation UIImage (WebP)
 


### PR DESCRIPTION
Even after the UIImage was collected, the underlying data wasn't being freed.
